### PR TITLE
Adding no shutdown to default IOS template.

### DIFF
--- a/3_Data_Models/ansible/roles/interfaces/templates/ios/interfaces.j2
+++ b/3_Data_Models/ansible/roles/interfaces/templates/ios/interfaces.j2
@@ -1,5 +1,6 @@
 {% for interface in interfaces %}
 interface {{ interface.name }}
+ no shutdown
  description {{ interface.description }}
  ip address {{ interface.ip | ipaddr('address') }} {{ interface.ip | ipaddr('netmask') }}
 !


### PR DESCRIPTION
Adding the no shutdown as the default command for IOS interface templates.