### PR TITLE
Interface description in incorrect location on junos Jinja2 template.

### DIFF
--- a/3_Data_Models/ansible/roles/interfaces/templates/junos/interfaces.j2
+++ b/3_Data_Models/ansible/roles/interfaces/templates/junos/interfaces.j2
@@ -3,8 +3,8 @@
 {% for interface in node.interfaces %}
 interfaces {
     {{ interface.name }} {
-        description "{{ interface.description }}";
 	unit 0 {
+            description "{{ interface.description }}"
             family inet {
                 address {{ interface.ip }};
             }


### PR DESCRIPTION
Resolving location of description so that NAPALM validation works as expected.